### PR TITLE
Updated the alert hook

### DIFF
--- a/iris_webhooks_module/IrisWebHooksInterface.py
+++ b/iris_webhooks_module/IrisWebHooksInterface.py
@@ -332,7 +332,7 @@ class IrisWebHooksInterface(IrisModuleInterface):
             }
 
         elif hook_object == 'alert':
-            object_url = f"{server_url}/alerts/filter?alert_ids={data[0].alert_id}"
+            object_url = f"{server_url}/alerts/filter?alert_ids={data[0]['alert_ids']}"
             raw_data = {
                 'alerts': AlertSchema(many=True).dump(data),
                 'object_url': object_url

--- a/iris_webhooks_module/IrisWebHooksInterface.py
+++ b/iris_webhooks_module/IrisWebHooksInterface.py
@@ -332,7 +332,10 @@ class IrisWebHooksInterface(IrisModuleInterface):
             }
 
         elif hook_object == 'alert':
-            object_url = f"{server_url}/alerts/filter?alert_ids={data[0]['alert_ids']}"
+            if isinstance(data[0], dict):
+                object_url = f"{server_url}/alerts/filter?alert_ids={data[0]['alert_ids']}"
+            else:
+                object_url = f"{server_url}/alerts/filter?alert_ids={data[0].alert_id}"
             raw_data = {
                 'alerts': AlertSchema(many=True).dump(data),
                 'object_url': object_url


### PR DESCRIPTION
The data that is being sent from the alert route is a dictionary. 
This is dependent on a fix in the iris-web repository to work with current state och the alert route. [PR-577](https://github.com/dfir-iris/iris-web/pull/577)