### PR TITLE
[ADD] Added request_headers as a optional key 

### DIFF
--- a/iris_webhooks_module/IrisWebHooksInterface.py
+++ b/iris_webhooks_module/IrisWebHooksInterface.py
@@ -387,10 +387,10 @@ class IrisWebHooksInterface(IrisModuleInterface):
             request_data = json.loads(req)
 
         url = hook.get('request_url')
-        request_header = hook.get('request_header') if hook.get('request_header') is not None else {}
+        request_headers = hook.get('request_headers') if hook.get('request_headers') is not None else {}
         verify_ssl = hook.get('verify_ssl') if hook.get('verify_ssl') is not None else True
 
-        result = requests.post(url, json=request_data, headers=request_header, verify=verify_ssl)
+        result = requests.post(url, json=request_data, headers=request_headers, verify=verify_ssl)
 
         try:
             result.raise_for_status()

--- a/iris_webhooks_module/IrisWebHooksInterface.py
+++ b/iris_webhooks_module/IrisWebHooksInterface.py
@@ -387,9 +387,10 @@ class IrisWebHooksInterface(IrisModuleInterface):
             request_data = json.loads(req)
 
         url = hook.get('request_url')
+        request_header = hook.get('request_header') if hook.get('request_header') is not None else {}
         verify_ssl = hook.get('verify_ssl') if hook.get('verify_ssl') is not None else True
 
-        result = requests.post(url, json=request_data, verify=verify_ssl)
+        result = requests.post(url, json=request_data, headers=request_header, verify=verify_ssl)
 
         try:
             result.raise_for_status()


### PR DESCRIPTION
This can be useful when authenticating to api's or services that reads api-keys, for example, from the headers

Without `request_headers`
```json
{
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate",
    "Connection": "keep-alive",
    "Content-Length": "32",
    "Content-Type": "application/json",
    "Host": "host.docker.internal:8086",
    "User-Agent": "python-requests/2.31.0"
}
```

With `request_headers` 
(`"request_headers": {"foo1":"bar1", "foo2":"bar2"}`)
```json
{
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate",
    "Connection": "keep-alive",
    "Content-Length": "32",
    "Content-Type": "application/json",
    "foo1": "bar1",
    "foo2": "bar2",
    "Host": "host.docker.internal:8086",
    "User-Agent": "python-requests/2.31.0"
}